### PR TITLE
Add : Apollo Provider

### DIFF
--- a/src/apollo.ts
+++ b/src/apollo.ts
@@ -1,20 +1,8 @@
-import { ApolloClient, gql, InMemoryCache } from "@apollo/client";
+import { ApolloClient, InMemoryCache } from "@apollo/client";
 
 const client = new ApolloClient({
   uri: "http://localhost:4000/",
   cache: new InMemoryCache(),
 });
-
-client
-  .query({
-    query: gql` 
-        {
-            allMovies: {
-                title
-            }
-        }
-    `,
-  })
-  .then((data) => console.log(data));
 
 export default client;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { ApolloProvider } from "@apollo/client";
+import client from "./apollo";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <ApolloProvider client={client}>
+      <App />
+    </ApolloProvider>
   </React.StrictMode>
 );

--- a/src/pages/Movies/index.tsx
+++ b/src/pages/Movies/index.tsx
@@ -1,5 +1,32 @@
+import { useEffect, useState } from "react";
+import { gql, useApolloClient } from "@apollo/client";
+
 function Movies() {
-  return <div>This is a list of movies</div>;
+  const [movies, setMovies] = useState([]);
+  const client = useApolloClient();
+
+  useEffect(() => {
+    client
+      .query({
+        query: gql`
+          {
+            allMovies {
+              title
+              id
+            }
+          }
+        `,
+      })
+      .then((result) => setMovies(result.data.allMovies));
+  }, [client]);
+
+  return (
+    <div>
+      {movies.map((movie) => (
+        <li key={movie.id}>{movie.title}</li>
+      ))}
+    </div>
+  );
 }
 
 export default Movies;


### PR DESCRIPTION
## Apollo Client와 React 컴포넌트 연결 

```typescript
// index.tsx

import { ApolloProvider } from "@apollo/client";
import client from "./apollo";

<ApolloProvider client={client}>
    <App />
</ApolloProvider>
 ```

## Client 접근
- ApolloProvider에 의해 전역에서 client 접근이 가능하다.

```typescript
import { useApolloClient } from '@apollo/client';

function Movies() {
    const client = useApolloClient();
    return <div>This is a list of movies</div>;
}
```