### PR TITLE
Add : local only field (isLiked)

### DIFF
--- a/src/pages/Movie/index.tsx
+++ b/src/pages/Movie/index.tsx
@@ -9,6 +9,7 @@ const GET_MOVIE = gql`
       title
       medium_cover_image
       rating
+      isLiked @client
     }
   }
 `;
@@ -27,6 +28,7 @@ function Movie() {
       <Column>
         <Title>{loading ? "Loading" : data?.movie?.title}</Title>
         <SubTitle>⭐️ {data?.movie?.rating}</SubTitle>
+        <button>{data?.movie?.isLiked ? "Unlike" : "Like"}</button>
       </Column>
       <Image bg={data?.movie?.medium_cover_image} />
     </Container>


### PR DESCRIPTION
## local only field
- Apollo의 cache에서만 활동하고, API로 가지 않는 field
- Apollo는 local only field를 제외한 모든 field의 정보를 API에 요청한다.

## 활용 사례
- 다크모드
- 사용자의 타임존 
- 사용자가 원하는 볼륨 크기를 User Profile에 저장 (ex. youtube)

## 선언 - @client
- Apollo에게 이 field는 cache에만 있다고 알려준다
```typescript
const GET_MOVIE = gql`
  query getMovie($movieId: String!) {
    movie(id: $movieId) {
      id
      title
      medium_cover_image
      rating
      isLiked @client // local only field
    }
  }
```
`;