### PR TITLE
Add : write fragment

### DIFF
--- a/src/pages/Movie/index.tsx
+++ b/src/pages/Movie/index.tsx
@@ -17,18 +17,38 @@ const GET_MOVIE = gql`
 function Movie() {
   const { id } = useParams();
 
-  const { data, loading } = useQuery(GET_MOVIE, {
+  const {
+    data,
+    loading,
+    client: { cache },
+  } = useQuery(GET_MOVIE, {
     variables: {
       movieId: id,
     },
   });
+
+  const handleBtnClick = () => {
+    cache.writeFragment({
+      id: `Movie:${id}`,
+      fragment: gql`
+        fragment MovieFragment on Movie {
+          isLiked
+        }
+      `,
+      data: {
+        isLiked: !data.movie.isLiked,
+      },
+    });
+  };
 
   return (
     <Container>
       <Column>
         <Title>{loading ? "Loading" : data?.movie?.title}</Title>
         <SubTitle>⭐️ {data?.movie?.rating}</SubTitle>
-        <button>{data?.movie?.isLiked ? "Unlike" : "Like"}</button>
+        <button onClick={handleBtnClick}>
+          {data?.movie?.isLiked ? "Unlike" : "Like"}
+        </button>
       </Column>
       <Image bg={data?.movie?.medium_cover_image} />
     </Container>


### PR DESCRIPTION
## Fragment
- 여러 쿼리에 사용될 수 있는, 재사용 가능한 필드셋
- 중복을 줄임으로써 전체 코드 간소화

## Usage
- 재사용되는 요소들 fragment로 분리
```typescript
const Names = gql`
   fragment names on People {
       first_name
       last_name 
   }
`;

const HealthInfo = gql`
   fragment healthInfo on People {
       sex
       blood_type 
   }
`;

const WorkInfo = gql`
   fragment workInfo on People {
       serve_years
       role
       team
   }
`;
```
- 쿼리에 적용
```typescript
const GET_PEOPLE = gql`
    query GetPeople {
      people {
        id
        ...names
        ...healthInfo
      }
    }
    ${Names}
    ${HealthInfo}
`;
```

## writeFragment
- 캐시에 데이터 쓰기
- 캐시된 데이터의 변경 사항은 GraphQL 서버로 푸시되지 않는다.
```typescript
  const handleBtnClick = () => {
      cache.writeFragment({
        id: `Movie:${id}`,
        fragment: gql`
          fragment MovieFragment on Movie {
            isLiked
          }
        `,
        data: {
          isLiked: !data.movie.isLiked,
        },
      });
    };
```